### PR TITLE
fixed security issue on header.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-  <link href="http://gmpg.org/xfn/11" rel="profile">
+  <link href="https://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
@@ -18,8 +18,8 @@
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}public/css/lanyon.css">
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400,400iftalic,700%7COpen+Sans:400">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400iftalic,700%7COpen+Sans:400">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-precomposed.png">

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -147,7 +147,7 @@ a:active, a:focus {
     padding-bottom: 1rem;
     margin-bottom: 3rem;
     border-bottom: 1px solid #E85151;
-    position: absolute;
+    position: fixed;
     left: 0;
     right: 0;
     height: 3.5em;


### PR DESCRIPTION
on firefox browsers, fonts will look like this if issue not patched
![xraarn](https://cloud.githubusercontent.com/assets/13377663/8892990/d023ed62-336a-11e5-8146-2e3a251e6278.png)
