### PR TITLE
centered tagline better

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
         <a id="b" href="http://twitter.com/ScottaBeTrue/"><i class="fa fa-twitter"></i></a>
         </contact>
       <div class="container">
-        <h3 class="masthead-title" style="margin-top: -3.3em;">
+        <h3 class="masthead-title" style="margin-top: -3.3em; text-align: center;">
             <a href="http://internaught.io" title="Home" style="position: absolute; left: 3.4em;">internaught.io</a>
             <small style="position: relative; margin-left: 55px; left: 30%; font-size: 1em">{{ site.tagline }}</small>
         </h3>


### PR DESCRIPTION
centered tagline relative to screen size, not relative to website name and social media icons

check the difference with [http://internaught.github.io/](http://internaught.github.io/) and [http://vm82.me/internaught.github.io/](http://vm82.me/internaught.github.io/), resize window horizontally
